### PR TITLE
Add cinematic WebGL scene suite

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 // src/App.tsx
 import React, { Suspense, lazy, useEffect, useState } from "react";
 const NeuralKnowledgeNetwork = lazy(() => import("./components/NeuralKnowledgeNetwork"));
+const CinematicScenes = lazy(() => import("./components/CinematicScenes"));
 
 type ApiNode = { id: string; kind: string; label: string; summary: string; degree: number; ts: number };
 type ApiEdge = { source: string; target: string; rel: string; weight: number; ts: number };
@@ -15,6 +16,8 @@ const BASE = import.meta.env.VITE_GRAPH_BASE || "/graph3d";
 const TAGS_BASE = import.meta.env.VITE_TAGS_BASE || "/tags";
 const TOKEN = import.meta.env.VITE_GRAPH_TOKEN || "";
 
+type ViewMode = "graph" | "cinematic";
+
 export default function App() {
   const [graph, setGraph] = useState<GraphPayload>({
     nodes: [],
@@ -24,6 +27,7 @@ export default function App() {
   const [tags, setTags] = useState<TagRow[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<ViewMode>("graph");
 
   useEffect(() => {
     const run = async () => {
@@ -60,59 +64,88 @@ export default function App() {
     <div className="w-screen h-screen bg-black text-white">
       {/* Header */}
       <header
-        className="flex items-center px-4 py-2 border-b border-neutral-800 bg-neutral-950/80 backdrop-blur"
+        className="flex items-center gap-3 px-4 py-2 border-b border-neutral-800 bg-neutral-950/80 backdrop-blur"
         style={{ minHeight: 48 }}
       >
         <strong className="text-sm md:text-base">Glyph Foundry</strong>
-        <span className="ml-3 text-xs md:text-sm text-neutral-400">
+        <span className="hidden sm:inline text-xs md:text-sm text-neutral-400">
           nodes: {graph.stats.node_count} • edges: {graph.stats.edge_count}
         </span>
-        {loading && <span className="ml-3 text-xs text-blue-400">loading…</span>}
+        {loading && <span className="text-xs text-blue-400">loading…</span>}
         {error && (
-          <span className="ml-3 text-xs text-red-400" role="alert">
+          <span className="text-xs text-red-400" role="alert">
             error: {error}
           </span>
         )}
-        <span className="ml-auto text-[11px] text-neutral-500">
-          window: {graph.stats.window_minutes}m
+        <span className="ml-auto flex items-center gap-2 text-[11px] text-neutral-500">
+          <span className="hidden sm:inline">window: {graph.stats.window_minutes}m</span>
+          <nav className="flex items-center gap-1 rounded-full border border-neutral-800 bg-neutral-950/80 p-1">
+            <button
+              type="button"
+              onClick={() => setView("graph")}
+              className={`px-3 py-1 text-[11px] uppercase tracking-[0.2em] rounded-full transition-colors ${
+                view === "graph"
+                  ? "bg-white text-black"
+                  : "text-neutral-400 hover:text-white"
+              }`}
+            >
+              Graph
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("cinematic")}
+              className={`px-3 py-1 text-[11px] uppercase tracking-[0.2em] rounded-full transition-colors ${
+                view === "cinematic"
+                  ? "bg-white text-black"
+                  : "text-neutral-400 hover:text-white"
+              }`}
+            >
+              Cinematic
+            </button>
+          </nav>
         </span>
       </header>
 
-      {/* Main layout */}
-      <main className="w-full h-[calc(100vh-48px)] grid grid-cols-1 md:grid-cols-[1fr_320px]">
-        {/* 3D Graph */}
-        <section className="relative">
-          <Suspense fallback={<div className="p-4 text-white">Loading 3D...</div>}>
-            <NeuralKnowledgeNetwork />
-          </Suspense>
-        </section>
-
-        {/* Tags panel */}
-        <aside className="hidden md:flex flex-col border-l border-neutral-800 bg-neutral-950/60 overflow-auto">
-          <div className="p-3 border-b border-neutral-800">
-            <h3 className="text-sm font-semibold">Tags</h3>
+      <main className="w-full h-[calc(100vh-48px)]">
+        {view === "graph" ? (
+          <div className="grid h-full w-full grid-cols-1 md:grid-cols-[1fr_320px]">
+            <section className="relative">
+              <Suspense fallback={<div className="p-4 text-white">Loading 3D...</div>}>
+                <NeuralKnowledgeNetwork />
+              </Suspense>
+            </section>
+            <aside className="hidden md:flex flex-col border-l border-neutral-800 bg-neutral-950/60 overflow-auto">
+              <div className="p-3 border-b border-neutral-800">
+                <h3 className="text-sm font-semibold">Tags</h3>
+              </div>
+              {tags.length === 0 ? (
+                <div className="p-4 text-neutral-500 text-sm">No tags</div>
+              ) : (
+                <ul className="p-3 space-y-3">
+                  {tags.map((t) => (
+                    <li key={`${t.tag_id}:${t.node_id}`} className="text-sm leading-tight">
+                      <code className="text-xs bg-neutral-900 px-1.5 py-0.5 rounded border border-neutral-800">
+                        {t.slug}
+                      </code>{" "}
+                      <span className="ml-1" title={t.tag_id}>
+                        {t.name}
+                      </span>
+                      <div className="text-[11px] text-neutral-500 mt-1">
+                        node={t.node_id.slice(0, 8)}… • conf={t.confidence}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </aside>
           </div>
-
-          {tags.length === 0 ? (
-            <div className="p-4 text-neutral-500 text-sm">No tags</div>
-          ) : (
-            <ul className="p-3 space-y-3">
-              {tags.map((t) => (
-                <li key={`${t.tag_id}:${t.node_id}`} className="text-sm leading-tight">
-                  <code className="text-xs bg-neutral-900 px-1.5 py-0.5 rounded border border-neutral-800">
-                    {t.slug}
-                  </code>{" "}
-                  <span className="ml-1" title={t.tag_id}>
-                    {t.name}
-                  </span>
-                  <div className="text-[11px] text-neutral-500 mt-1">
-                    node={t.node_id.slice(0, 8)}… • conf={t.confidence}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </aside>
+        ) : (
+          <section className="h-full w-full">
+            <Suspense fallback={<div className="p-4 text-white">Loading cinematic renderer…</div>}>
+              <CinematicScenes />
+            </Suspense>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/frontend/src/components/CinematicScenes.tsx
+++ b/frontend/src/components/CinematicScenes.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { QCEngine } from "../qce/QCEngine";
+
+const SCENE_NAMES = [
+  "NeuralConstellation",
+  "QuantumWavefield",
+  "VolumetricSpines",
+  "ParticleVortex",
+] as const;
+
+type SceneName = (typeof SCENE_NAMES)[number];
+
+export default function CinematicScenes() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const engineRef = useRef<QCEngine | null>(null);
+  const [active, setActive] = useState<SceneName>("NeuralConstellation");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    try {
+      const engine = new QCEngine(canvas);
+      engineRef.current = engine;
+      engine.start();
+      engine.setScene(active);
+      const handle = () => engine.resize();
+      handle();
+      const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(handle) : null;
+      if (observer && containerRef.current) {
+        observer.observe(containerRef.current);
+      } else {
+        window.addEventListener("resize", handle);
+      }
+      return () => {
+        if (observer) {
+          observer.disconnect();
+        } else {
+          window.removeEventListener("resize", handle);
+        }
+        engine.dispose();
+        engineRef.current = null;
+      };
+    } catch (e: any) {
+      setError(e?.message || "Unable to start cinematic engine");
+    }
+  }, []);
+
+  useEffect(() => {
+    engineRef.current?.setScene(active);
+  }, [active]);
+
+  const buttons = useMemo(
+    () =>
+      SCENE_NAMES.map((name) => (
+        <button
+          key={name}
+          onClick={() => setActive(name)}
+          className={`px-3 py-1.5 text-xs uppercase tracking-[0.2em] rounded transition-colors border ${
+            active === name
+              ? "border-white/70 bg-white/10 text-white"
+              : "border-white/10 bg-black/30 text-white/70 hover:text-white hover:border-white/40"
+          }`}
+          type="button"
+        >
+          {name.replace(/([a-z])([A-Z])/g, "$1 $2")}
+        </button>
+      )),
+    [active]
+  );
+
+  return (
+    <div ref={containerRef} className="relative h-full w-full overflow-hidden bg-black">
+      <canvas ref={canvasRef} className="h-full w-full" />
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/40 via-transparent to-black/60" />
+      <div className="pointer-events-auto absolute top-4 left-4 flex flex-wrap gap-2 rounded-xl border border-white/10 bg-black/50 px-4 py-3 backdrop-blur">
+        {buttons}
+      </div>
+      <div className="pointer-events-none absolute bottom-4 left-4 max-w-sm rounded-lg border border-white/10 bg-black/40 px-4 py-3 text-xs text-white/80 backdrop-blur">
+        <p className="font-semibold uppercase tracking-[0.3em] text-white/70">Cinematic Neural Atlas</p>
+        <p className="mt-2 leading-relaxed text-white/70">
+          Explore four shader-driven narratives rendered in HDR: constellations of thought, quantum
+          interference, volumetric spines, and a transform-feedback particle vortex.
+        </p>
+      </div>
+      {error && (
+        <div className="pointer-events-auto absolute bottom-4 right-4 max-w-xs rounded-lg border border-red-400/40 bg-red-500/10 px-4 py-3 text-xs text-red-200">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/qce/QCEngine.ts
+++ b/frontend/src/qce/QCEngine.ts
@@ -1,0 +1,111 @@
+import { CinematicCamera } from "./engine/core/Camera";
+import { HDRPipeline } from "./engine/core/HDRPipeline";
+import { TFParticleSim } from "./engine/particles/TFParticleSim";
+import { SceneManager } from "./scenes/SceneManager";
+import { NeuralConstellation } from "./scenes/NeuralConstellation";
+import { ParticleVortex } from "./scenes/ParticleVortex";
+import { QuantumWavefield } from "./scenes/QuantumWavefield";
+import { VolumetricSpines } from "./scenes/VolumetricSpines";
+
+export class QCEngine {
+  private canvas: HTMLCanvasElement;
+  private gl!: WebGL2RenderingContext;
+  private running = false;
+  private animationFrame: number | null = null;
+  private lastTime = 0;
+  private time = 0;
+  private pipeline!: HDRPipeline;
+  private camera!: CinematicCamera;
+  private tfSim!: TFParticleSim;
+  private scenes!: SceneManager;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+  }
+
+  start() {
+    const gl = this.canvas.getContext("webgl2", {
+      antialias: false,
+      alpha: false,
+      powerPreference: "high-performance",
+    });
+    if (!gl) throw new Error("WebGL2 not supported");
+    this.gl = gl;
+
+    gl.enable(gl.DEPTH_TEST);
+    gl.depthFunc(gl.LEQUAL);
+    gl.disable(gl.CULL_FACE);
+
+    this.pipeline = new HDRPipeline(gl);
+    this.camera = new CinematicCamera();
+    this.tfSim = new TFParticleSim(gl);
+    this.scenes = new SceneManager(gl);
+    this.scenes.register(new NeuralConstellation());
+    this.scenes.register(new QuantumWavefield());
+    this.scenes.register(new VolumetricSpines());
+    this.scenes.register(new ParticleVortex(this.tfSim));
+
+    this.resize();
+    window.addEventListener("resize", this.handleResize);
+
+    this.running = true;
+    this.lastTime = performance.now();
+    this.time = 0;
+    this.setScene("NeuralConstellation");
+    this.animationFrame = requestAnimationFrame(this.loop);
+  }
+
+  private loop = (now: number) => {
+    if (!this.running) return;
+    const dt = (now - this.lastTime) / 1000;
+    this.lastTime = now;
+    const clampedDt = Math.min(dt, 1 / 15);
+    this.time += clampedDt;
+
+    this.camera.update(clampedDt);
+    this.tfSim.update(this.time, clampedDt);
+
+    const gl = this.gl;
+    this.pipeline.bindHDR();
+    gl.clearColor(0.043, 0.055, 0.063, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    this.scenes.draw(this.camera, this.time, clampedDt);
+
+    this.pipeline.resolve(1.15);
+
+    this.animationFrame = requestAnimationFrame(this.loop);
+  };
+
+  setScene(name: string) {
+    if (!this.scenes) return;
+    this.scenes.use(name);
+  }
+
+  resize = () => {
+    if (!this.gl) return;
+    const dpr = Math.min(window.devicePixelRatio || 1, 1.75);
+    const width = this.canvas.clientWidth * dpr;
+    const height = this.canvas.clientHeight * dpr;
+    if (!width || !height) return;
+    this.canvas.width = Math.floor(width);
+    this.canvas.height = Math.floor(height);
+    this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    this.pipeline.resize(this.canvas.width, this.canvas.height);
+    this.camera.setViewport(this.canvas.width, this.canvas.height);
+    this.scenes.resize();
+  };
+
+  private handleResize = () => {
+    this.resize();
+  };
+
+  dispose() {
+    this.running = false;
+    if (this.animationFrame !== null) cancelAnimationFrame(this.animationFrame);
+    window.removeEventListener("resize", this.handleResize);
+    this.scenes?.disposeAll();
+    this.tfSim?.dispose();
+    this.pipeline?.dispose();
+  }
+}

--- a/frontend/src/qce/engine/core/Camera.ts
+++ b/frontend/src/qce/engine/core/Camera.ts
@@ -1,0 +1,140 @@
+const DEG2RAD = Math.PI / 180;
+
+function normalize(out: Float32Array, v: Float32Array) {
+  const x = v[0];
+  const y = v[1];
+  const z = v[2];
+  let len = Math.hypot(x, y, z);
+  if (len === 0) len = 1;
+  const inv = 1 / len;
+  out[0] = x * inv;
+  out[1] = y * inv;
+  out[2] = z * inv;
+}
+
+function subtract(out: Float32Array, a: Float32Array, b: Float32Array) {
+  out[0] = a[0] - b[0];
+  out[1] = a[1] - b[1];
+  out[2] = a[2] - b[2];
+}
+
+function cross(out: Float32Array, a: Float32Array, b: Float32Array) {
+  const ax = a[0];
+  const ay = a[1];
+  const az = a[2];
+  const bx = b[0];
+  const by = b[1];
+  const bz = b[2];
+  out[0] = ay * bz - az * by;
+  out[1] = az * bx - ax * bz;
+  out[2] = ax * by - ay * bx;
+}
+
+function perspective(out: Float32Array, fov: number, aspect: number, near: number, far: number) {
+  const f = 1.0 / Math.tan((fov * DEG2RAD) / 2);
+  out[0] = f / aspect;
+  out[1] = 0;
+  out[2] = 0;
+  out[3] = 0;
+
+  out[4] = 0;
+  out[5] = f;
+  out[6] = 0;
+  out[7] = 0;
+
+  out[8] = 0;
+  out[9] = 0;
+  out[11] = -1;
+
+  if (far !== Infinity) {
+    const nf = 1 / (near - far);
+    out[10] = (far + near) * nf;
+    out[14] = 2 * far * near * nf;
+  } else {
+    out[10] = -1;
+    out[14] = -2 * near;
+  }
+
+  out[12] = 0;
+  out[13] = 0;
+  out[15] = 0;
+}
+
+function lookAt(out: Float32Array, eye: Float32Array, center: Float32Array, up: Float32Array) {
+  const xAxis = new Float32Array(3);
+  const yAxis = new Float32Array(3);
+  const zAxis = new Float32Array(3);
+
+  subtract(zAxis, eye, center);
+  normalize(zAxis, zAxis);
+
+  cross(xAxis, up, zAxis);
+  normalize(xAxis, xAxis);
+
+  cross(yAxis, zAxis, xAxis);
+
+  out[0] = xAxis[0];
+  out[1] = yAxis[0];
+  out[2] = zAxis[0];
+  out[3] = 0;
+
+  out[4] = xAxis[1];
+  out[5] = yAxis[1];
+  out[6] = zAxis[1];
+  out[7] = 0;
+
+  out[8] = xAxis[2];
+  out[9] = yAxis[2];
+  out[10] = zAxis[2];
+  out[11] = 0;
+
+  out[12] = -(xAxis[0] * eye[0] + xAxis[1] * eye[1] + xAxis[2] * eye[2]);
+  out[13] = -(yAxis[0] * eye[0] + yAxis[1] * eye[1] + yAxis[2] * eye[2]);
+  out[14] = -(zAxis[0] * eye[0] + zAxis[1] * eye[1] + zAxis[2] * eye[2]);
+  out[15] = 1;
+}
+
+export class CinematicCamera {
+  proj = new Float32Array(16);
+  view = new Float32Array(16);
+  position = new Float32Array([0, 40, 420]);
+  target = new Float32Array([0, 0, 0]);
+  up = new Float32Array([0, 1, 0]);
+  private aspect = 1;
+  private radius = 420;
+  private theta = 0;
+
+  constructor() {
+    this.setPerspective(45, 1, 0.1, 4000);
+    this.updateView();
+  }
+
+  setPerspective(fov: number, aspect: number, near: number, far: number) {
+    this.aspect = aspect;
+    perspective(this.proj, fov, aspect, near, far);
+  }
+
+  setViewport(width: number, height: number) {
+    const aspect = height === 0 ? 1 : width / height;
+    this.setPerspective(45, aspect, 0.1, 4000);
+  }
+
+  setRadius(radius: number) {
+    this.radius = radius;
+  }
+
+  update(dt: number) {
+    this.theta += dt * 0.25;
+    const orbitX = Math.cos(this.theta) * this.radius;
+    const orbitZ = Math.sin(this.theta) * this.radius;
+    const vertical = Math.sin(this.theta * 0.45) * this.radius * 0.18 + 60;
+    this.position[0] = orbitX;
+    this.position[1] = vertical;
+    this.position[2] = orbitZ;
+    this.updateView();
+  }
+
+  private updateView() {
+    lookAt(this.view, this.position, this.target, this.up);
+  }
+}

--- a/frontend/src/qce/engine/core/GLUtils.ts
+++ b/frontend/src/qce/engine/core/GLUtils.ts
@@ -1,0 +1,46 @@
+export function compile(gl: WebGL2RenderingContext, type: number, source: string): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error("Failed to create shader");
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const info = gl.getShaderInfoLog(shader);
+    gl.deleteShader(shader);
+    throw new Error(`Shader compile error: ${info || "unknown"}`);
+  }
+  return shader;
+}
+
+export function link(gl: WebGL2RenderingContext, ...shaders: WebGLShader[]): WebGLProgram {
+  const program = gl.createProgram();
+  if (!program) throw new Error("Failed to create program");
+  shaders.forEach((shader) => gl.attachShader(program, shader));
+  gl.linkProgram(program);
+  shaders.forEach((shader) => gl.detachShader(program, shader));
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const info = gl.getProgramInfoLog(program);
+    gl.deleteProgram(program);
+    throw new Error(`Program link error: ${info || "unknown"}`);
+  }
+  return program;
+}
+
+export function deleteProgram(gl: WebGL2RenderingContext, program?: WebGLProgram | null) {
+  if (program) gl.deleteProgram(program);
+}
+
+export function deleteBuffer(gl: WebGL2RenderingContext, buffer?: WebGLBuffer | null) {
+  if (buffer) gl.deleteBuffer(buffer);
+}
+
+export function deleteVertexArray(gl: WebGL2RenderingContext, vao?: WebGLVertexArrayObject | null) {
+  if (vao) gl.deleteVertexArray(vao);
+}
+
+export function deleteTexture(gl: WebGL2RenderingContext, texture?: WebGLTexture | null) {
+  if (texture) gl.deleteTexture(texture);
+}
+
+export function deleteRenderbuffer(gl: WebGL2RenderingContext, buffer?: WebGLRenderbuffer | null) {
+  if (buffer) gl.deleteRenderbuffer(buffer);
+}

--- a/frontend/src/qce/engine/core/HDRPipeline.ts
+++ b/frontend/src/qce/engine/core/HDRPipeline.ts
@@ -1,0 +1,139 @@
+import { compile, deleteProgram, deleteRenderbuffer, deleteTexture, link } from "./GLUtils";
+
+const VS = `#version 300 es
+layout(location=0) in vec2 a_pos;
+out vec2 vUV;
+void main(){
+  vUV = a_pos * 0.5 + 0.5;
+  gl_Position = vec4(a_pos, 0.0, 1.0);
+}`;
+
+const FS = `#version 300 es
+precision highp float;
+in vec2 vUV;
+uniform sampler2D uColor;
+uniform float uExposure;
+out vec4 frag;
+
+vec3 aces(vec3 x){
+  const mat3 ACESInputMat = mat3(
+    0.59719, 0.35458, 0.04823,
+    0.07600, 0.90834, 0.01566,
+    0.02840, 0.13383, 0.83777
+  );
+  const mat3 ACESOutputMat = mat3(
+    1.60475, -0.53108, -0.07367,
+    -0.10208,  1.10813, -0.00605,
+    -0.00327, -0.07276,  1.07602
+  );
+  x = ACESInputMat * x;
+  const vec3 a = x * (x + 0.0245786) - 0.000090537;
+  const vec3 b = x * (0.983729 * x + 0.4329510) + 0.238081;
+  vec3 c = a / b;
+  c = ACESOutputMat * c;
+  return clamp(c, 0.0, 1.0);
+}
+
+void main(){
+  vec3 hdr = texture(uColor, vUV).rgb * uExposure;
+  vec3 col = aces(hdr);
+  frag = vec4(col, 1.0);
+}`;
+
+export class HDRPipeline {
+  private gl: WebGL2RenderingContext;
+  private width = 1;
+  private height = 1;
+  private framebuffer: WebGLFramebuffer | null = null;
+  private color: WebGLTexture | null = null;
+  private depth: WebGLRenderbuffer | null = null;
+  private vao: WebGLVertexArrayObject | null = null;
+  private program: WebGLProgram | null = null;
+  private uExposure: WebGLUniformLocation | null = null;
+
+  constructor(gl: WebGL2RenderingContext) {
+    this.gl = gl;
+    this.setupProgram();
+    this.resize(gl.canvas.width || 1, gl.canvas.height || 1);
+  }
+
+  private setupProgram() {
+    const gl = this.gl;
+    const vs = compile(gl, gl.VERTEX_SHADER, VS);
+    const fs = compile(gl, gl.FRAGMENT_SHADER, FS);
+    this.program = link(gl, vs, fs);
+    this.uExposure = gl.getUniformLocation(this.program, "uExposure");
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+
+    this.vao = gl.createVertexArray();
+    gl.bindVertexArray(this.vao);
+    const vbo = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+  }
+
+  resize(width: number, height: number) {
+    const gl = this.gl;
+    if (width === this.width && height === this.height) return;
+    this.width = Math.max(1, Math.floor(width));
+    this.height = Math.max(1, Math.floor(height));
+
+    if (!this.framebuffer) this.framebuffer = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+
+    if (!this.color) this.color = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, this.color);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA16F, this.width, this.height, 0, gl.RGBA, gl.FLOAT, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.color, 0);
+
+    if (!this.depth) this.depth = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, this.depth);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT24, this.width, this.height);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, this.depth);
+
+    const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (status !== gl.FRAMEBUFFER_COMPLETE) {
+      throw new Error(`HDR framebuffer incomplete: 0x${status.toString(16)}`);
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  }
+
+  bindHDR() {
+    const gl = this.gl;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffer);
+    gl.viewport(0, 0, this.width, this.height);
+  }
+
+  resolve(exposure = 1.1) {
+    const gl = this.gl;
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+    gl.disable(gl.DEPTH_TEST);
+    gl.useProgram(this.program);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.color);
+    gl.uniform1f(this.uExposure, exposure);
+    gl.bindVertexArray(this.vao);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+    gl.bindVertexArray(null);
+    gl.enable(gl.DEPTH_TEST);
+  }
+
+  dispose() {
+    const gl = this.gl;
+    if (this.framebuffer) gl.deleteFramebuffer(this.framebuffer);
+    deleteTexture(gl, this.color);
+    deleteRenderbuffer(gl, this.depth);
+    if (this.vao) gl.deleteVertexArray(this.vao);
+    deleteProgram(gl, this.program);
+  }
+}

--- a/frontend/src/qce/engine/particles/TFParticleSim.ts
+++ b/frontend/src/qce/engine/particles/TFParticleSim.ts
@@ -1,0 +1,181 @@
+import { compile, deleteBuffer, deleteProgram, deleteVertexArray } from "../core/GLUtils";
+
+const UPDATE_VS = `#version 300 es
+precision highp float;
+layout(location=0) in vec3 i_pos;
+layout(location=1) in vec3 i_vel;
+uniform float uTime;
+uniform float uDelta;
+out vec3 o_pos;
+out vec3 o_vel;
+
+vec3 swirl(vec3 p, float time) {
+  float angle = time * 0.25;
+  mat3 rot = mat3(
+    cos(angle), 0.0, -sin(angle),
+    0.0,        1.0, 0.0,
+    sin(angle), 0.0, cos(angle)
+  );
+  return rot * p;
+}
+
+void main() {
+  vec3 pos = i_pos;
+  vec3 vel = i_vel;
+
+  vec3 toward = normalize(-pos + vec3(0.0, sin(uTime * 0.4) * 40.0, 0.0));
+  vec3 swirlForce = normalize(swirl(pos, uTime) - pos + vec3(0.0, 0.2, 0.0));
+  if (!all(greaterThan(toward * toward, vec3(0.0)))) {
+    toward = vec3(0.0, 1.0, 0.0);
+  }
+
+  float speed = length(vel);
+  vel += (toward * 0.7 + swirlForce * 0.3) * uDelta * 90.0;
+  vel -= vel * min(1.0, uDelta * 1.6);
+  vel += vec3(
+    sin(uTime + pos.y * 0.01),
+    cos(uTime * 0.8 + pos.x * 0.01),
+    sin(uTime * 0.6 + pos.z * 0.01)
+  ) * 0.08 * uDelta;
+
+  pos += vel * uDelta * 60.0;
+
+  float radius = length(pos.xz);
+  if (radius > 480.0) {
+    vec3 dir = pos / max(radius, 0.001);
+    pos -= dir * (radius - 480.0);
+    vel -= dir * speed * 0.6;
+  }
+
+  if (pos.y > 260.0) {
+    pos.y = 260.0;
+    vel.y *= -0.2;
+  }
+  if (pos.y < -260.0) {
+    pos.y = -260.0;
+    vel.y *= -0.2;
+  }
+
+  o_pos = pos;
+  o_vel = vel;
+}`;
+
+export type ParticleBuffer = {
+  vao: WebGLVertexArrayObject;
+  position: WebGLBuffer;
+  velocity: WebGLBuffer;
+};
+
+export class TFParticleSim {
+  private gl: WebGL2RenderingContext;
+  readonly count: number;
+  private updateProgram: WebGLProgram;
+  private read: ParticleBuffer;
+  private write: ParticleBuffer;
+  private feedback: WebGLTransformFeedback;
+  private uTime: WebGLUniformLocation;
+  private uDelta: WebGLUniformLocation;
+
+  constructor(gl: WebGL2RenderingContext, count = 400_000) {
+    this.gl = gl;
+    this.count = count;
+    const vs = compile(gl, gl.VERTEX_SHADER, UPDATE_VS);
+    this.updateProgram = gl.createProgram()!;
+    gl.attachShader(this.updateProgram, vs);
+    gl.transformFeedbackVaryings(this.updateProgram, ["o_pos", "o_vel"], gl.SEPARATE_ATTRIBS);
+    gl.linkProgram(this.updateProgram);
+    gl.deleteShader(vs);
+    if (!gl.getProgramParameter(this.updateProgram, gl.LINK_STATUS)) {
+      const info = gl.getProgramInfoLog(this.updateProgram);
+      gl.deleteProgram(this.updateProgram);
+      throw new Error(`Particle update program link error: ${info || "unknown"}`);
+    }
+    this.uTime = gl.getUniformLocation(this.updateProgram, "uTime")!;
+    this.uDelta = gl.getUniformLocation(this.updateProgram, "uDelta")!;
+
+    this.read = this.createBuffers();
+    this.write = this.createBuffers();
+    this.feedback = gl.createTransformFeedback()!;
+  }
+
+  private createBuffers(): ParticleBuffer {
+    const gl = this.gl;
+    const vao = gl.createVertexArray()!;
+    gl.bindVertexArray(vao);
+
+    const position = gl.createBuffer()!;
+    const velocity = gl.createBuffer()!;
+
+    const posData = new Float32Array(this.count * 3);
+    const velData = new Float32Array(this.count * 3);
+    for (let i = 0; i < this.count; i++) {
+      const r = Math.random() * 320;
+      const theta = Math.random() * Math.PI * 2;
+      const y = (Math.random() - 0.5) * 180;
+      posData[i * 3 + 0] = Math.cos(theta) * r;
+      posData[i * 3 + 1] = y;
+      posData[i * 3 + 2] = Math.sin(theta) * r;
+      velData[i * 3 + 0] = (Math.random() - 0.5) * 2;
+      velData[i * 3 + 1] = (Math.random() - 0.5) * 2;
+      velData[i * 3 + 2] = (Math.random() - 0.5) * 2;
+    }
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, position);
+    gl.bufferData(gl.ARRAY_BUFFER, posData, gl.DYNAMIC_COPY);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, velocity);
+    gl.bufferData(gl.ARRAY_BUFFER, velData, gl.DYNAMIC_COPY);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 0, 0);
+
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+    return { vao, position, velocity };
+  }
+
+  update(time: number, delta: number) {
+    const gl = this.gl;
+    gl.useProgram(this.updateProgram);
+    gl.uniform1f(this.uTime, time);
+    gl.uniform1f(this.uDelta, delta);
+
+    gl.enable(gl.RASTERIZER_DISCARD);
+    gl.bindVertexArray(this.read.vao);
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, this.feedback);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, this.write.position);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, this.write.velocity);
+
+    gl.beginTransformFeedback(gl.POINTS);
+    gl.drawArrays(gl.POINTS, 0, this.count);
+    gl.endTransformFeedback();
+
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
+    gl.bindVertexArray(null);
+    gl.disable(gl.RASTERIZER_DISCARD);
+
+    const tmp = this.read;
+    this.read = this.write;
+    this.write = tmp;
+  }
+
+  get readBuffer() {
+    return this.read;
+  }
+
+  dispose() {
+    const gl = this.gl;
+    deleteVertexArray(gl, this.read.vao);
+    deleteBuffer(gl, this.read.position);
+    deleteBuffer(gl, this.read.velocity);
+    deleteVertexArray(gl, this.write.vao);
+    deleteBuffer(gl, this.write.position);
+    deleteBuffer(gl, this.write.velocity);
+    gl.deleteTransformFeedback(this.feedback);
+    deleteProgram(gl, this.updateProgram);
+  }
+}

--- a/frontend/src/qce/scenes/NeuralConstellation.ts
+++ b/frontend/src/qce/scenes/NeuralConstellation.ts
@@ -1,0 +1,166 @@
+import { Scene } from "./SceneTypes";
+import { compile, deleteBuffer, deleteProgram, deleteVertexArray, link } from "../engine/core/GLUtils";
+
+const VS_POINTS = `#version 300 es
+precision highp float;
+layout(location=0) in vec3 a_pos;
+uniform mat4 uProj, uView;
+uniform float uSize;
+out float vGlow;
+void main(){
+  vec4 mv = uView * vec4(a_pos,1.0);
+  gl_Position = uProj * mv;
+  gl_PointSize = uSize * (280.0 / -mv.z);
+  vGlow = clamp(1.0 / (0.02 + length(mv.xyz)*0.015), 0.0, 1.0);
+}
+`;
+
+const FS_POINTS = `#version 300 es
+precision highp float;
+in float vGlow;
+out vec4 frag;
+void main(){
+  vec2 uv = gl_PointCoord - 0.5;
+  float r = dot(uv,uv);
+  float core = exp(-r*36.0);
+  float halo = exp(-r*4.5)*0.6;
+  vec3 col = mix(vec3(0.169,0.894,0.953), vec3(1.0,0.431,0.227), clamp(uv.y+0.5,0.0,1.0));
+  float a = core + halo*vGlow;
+  frag = vec4(col, a);
+}
+`;
+
+const VS_LINES = `#version 300 es
+precision highp float;
+layout(location=0) in vec3 a_src;
+layout(location=1) in vec3 a_dst;
+uniform mat4 uProj, uView;
+out float vFade;
+void main(){
+  vec3 p = mix(a_src, a_dst, float((gl_VertexID & 1) == 1));
+  vec4 mv = uView * vec4(p, 1.0);
+  gl_Position = uProj * mv;
+  vFade = clamp(0.8 - length(mv.xyz)*0.002, 0.0, 0.8);
+}
+`;
+
+const FS_LINES = `#version 300 es
+precision highp float;
+in float vFade;
+out vec4 frag;
+void main(){
+  vec3 cyan = vec3(0.169,0.894,0.953);
+  vec3 ember = vec3(1.0,0.431,0.227);
+  vec3 col = mix(cyan, ember, vFade*0.9);
+  frag = vec4(col, vFade);
+}
+`;
+
+export class NeuralConstellation implements Scene {
+  name = "NeuralConstellation";
+  private progPoints!: WebGLProgram;
+  private progLines!: WebGLProgram;
+  private uProjP!: WebGLUniformLocation;
+  private uViewP!: WebGLUniformLocation;
+  private uSize!: WebGLUniformLocation;
+  private uProjL!: WebGLUniformLocation;
+  private uViewL!: WebGLUniformLocation;
+  private vaoPoints!: WebGLVertexArrayObject;
+  private vaoLines!: WebGLVertexArrayObject;
+  private pointsBuffer!: WebGLBuffer;
+  private lineSrcBuffer!: WebGLBuffer;
+  private lineDstBuffer!: WebGLBuffer;
+  private countPoints = 120_000;
+  private countLines = 40_000;
+
+  init(gl: WebGL2RenderingContext) {
+    this.progPoints = link(
+      gl,
+      compile(gl, gl.VERTEX_SHADER, VS_POINTS),
+      compile(gl, gl.FRAGMENT_SHADER, FS_POINTS)
+    );
+    this.uProjP = gl.getUniformLocation(this.progPoints, "uProj")!;
+    this.uViewP = gl.getUniformLocation(this.progPoints, "uView")!;
+    this.uSize = gl.getUniformLocation(this.progPoints, "uSize")!;
+
+    this.progLines = link(
+      gl,
+      compile(gl, gl.VERTEX_SHADER, VS_LINES),
+      compile(gl, gl.FRAGMENT_SHADER, FS_LINES)
+    );
+    this.uProjL = gl.getUniformLocation(this.progLines, "uProj")!;
+    this.uViewL = gl.getUniformLocation(this.progLines, "uView")!;
+
+    const pPos = new Float32Array(this.countPoints * 3);
+    for (let i = 0; i < this.countPoints; i++) {
+      const t = i / this.countPoints;
+      const a = 2.39996323 * i;
+      const r = 90 * Math.sqrt(t);
+      pPos[i * 3 + 0] = Math.cos(a) * r * (Math.random() * 0.3 + 0.7);
+      pPos[i * 3 + 1] = (Math.random() - 0.5) * 90;
+      pPos[i * 3 + 2] = Math.sin(a) * r * (Math.random() * 0.3 + 0.7);
+    }
+    this.vaoPoints = gl.createVertexArray()!;
+    gl.bindVertexArray(this.vaoPoints);
+    this.pointsBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.pointsBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, pPos, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+
+    const lineSrc = new Float32Array(this.countLines * 3);
+    const lineDst = new Float32Array(this.countLines * 3);
+    for (let i = 0; i < this.countLines; i++) {
+      const a = (Math.random() * this.countPoints) | 0;
+      const b = (a + ((Math.random() * 400) | 0)) % this.countPoints;
+      lineSrc[i * 3 + 0] = pPos[a * 3 + 0];
+      lineSrc[i * 3 + 1] = pPos[a * 3 + 1];
+      lineSrc[i * 3 + 2] = pPos[a * 3 + 2];
+      lineDst[i * 3 + 0] = pPos[b * 3 + 0];
+      lineDst[i * 3 + 1] = pPos[b * 3 + 1];
+      lineDst[i * 3 + 2] = pPos[b * 3 + 2];
+    }
+    this.vaoLines = gl.createVertexArray()!;
+    gl.bindVertexArray(this.vaoLines);
+    this.lineSrcBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.lineSrcBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, lineSrc, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+    this.lineDstBuffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.lineDstBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, lineDst, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+  }
+
+  draw(gl: WebGL2RenderingContext, camera: { proj: Float32Array; view: Float32Array }, t: number) {
+    gl.useProgram(this.progLines);
+    gl.uniformMatrix4fv(this.uProjL, false, camera.proj);
+    gl.uniformMatrix4fv(this.uViewL, false, camera.view);
+    gl.bindVertexArray(this.vaoLines);
+    gl.drawArrays(gl.LINES, 0, this.countLines * 2);
+    gl.bindVertexArray(null);
+
+    gl.useProgram(this.progPoints);
+    gl.uniformMatrix4fv(this.uProjP, false, camera.proj);
+    gl.uniformMatrix4fv(this.uViewP, false, camera.view);
+    gl.uniform1f(this.uSize, 1.6 + Math.sin(t * 0.4) * 0.2);
+    gl.bindVertexArray(this.vaoPoints);
+    gl.drawArrays(gl.POINTS, 0, this.countPoints);
+    gl.bindVertexArray(null);
+  }
+
+  dispose(gl: WebGL2RenderingContext) {
+    deleteProgram(gl, this.progPoints);
+    deleteProgram(gl, this.progLines);
+    deleteVertexArray(gl, this.vaoPoints);
+    deleteVertexArray(gl, this.vaoLines);
+    deleteBuffer(gl, this.pointsBuffer);
+    deleteBuffer(gl, this.lineSrcBuffer);
+    deleteBuffer(gl, this.lineDstBuffer);
+  }
+}

--- a/frontend/src/qce/scenes/ParticleVortex.ts
+++ b/frontend/src/qce/scenes/ParticleVortex.ts
@@ -1,0 +1,68 @@
+import { Scene } from "./SceneTypes";
+import { compile, deleteProgram, link } from "../engine/core/GLUtils";
+import type { TFParticleSim } from "../engine/particles/TFParticleSim";
+
+const VS = `#version 300 es
+precision highp float;
+layout(location=0) in vec3 a_pos;
+uniform mat4 uProj, uView;
+uniform float uSize;
+out float vS;
+void main(){
+  vec4 mv = uView * vec4(a_pos,1.0);
+  gl_Position = uProj * mv;
+  gl_PointSize = uSize * (300.0 / -mv.z);
+  vS = clamp(1.0 / (0.05 + length(mv.xyz)*0.01), 0.0, 1.0);
+}
+`;
+
+const FS = `#version 300 es
+precision highp float;
+in float vS;
+out vec4 frag;
+void main(){
+  vec2 uv = gl_PointCoord - 0.5;
+  float r = dot(uv,uv);
+  float soft = exp(-r*16.0);
+  vec3 col = mix(vec3(0.169,0.894,0.953), vec3(1.0,0.431,0.227), vS*0.9);
+  frag = vec4(col, soft);
+}
+`;
+
+export class ParticleVortex implements Scene {
+  name = "ParticleVortex";
+  private tf: TFParticleSim;
+  private prog!: WebGLProgram;
+  private uProj!: WebGLUniformLocation;
+  private uView!: WebGLUniformLocation;
+  private uSize!: WebGLUniformLocation;
+
+  constructor(tfSim: TFParticleSim) {
+    this.tf = tfSim;
+  }
+
+  init(gl: WebGL2RenderingContext) {
+    this.prog = link(gl, compile(gl, gl.VERTEX_SHADER, VS), compile(gl, gl.FRAGMENT_SHADER, FS));
+    this.uProj = gl.getUniformLocation(this.prog, "uProj")!;
+    this.uView = gl.getUniformLocation(this.prog, "uView")!;
+    this.uSize = gl.getUniformLocation(this.prog, "uSize")!;
+  }
+
+  draw(gl: WebGL2RenderingContext, camera: { proj: Float32Array; view: Float32Array }, t: number) {
+    const size = 1.2 + Math.sin(t * 0.6) * 0.2;
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+    gl.useProgram(this.prog);
+    gl.uniformMatrix4fv(this.uProj, false, camera.proj);
+    gl.uniformMatrix4fv(this.uView, false, camera.view);
+    gl.uniform1f(this.uSize, size);
+    gl.bindVertexArray(this.tf.readBuffer.vao);
+    gl.drawArrays(gl.POINTS, 0, this.tf.count);
+    gl.bindVertexArray(null);
+    gl.disable(gl.BLEND);
+  }
+
+  dispose(gl: WebGL2RenderingContext) {
+    deleteProgram(gl, this.prog);
+  }
+}

--- a/frontend/src/qce/scenes/QuantumWavefield.ts
+++ b/frontend/src/qce/scenes/QuantumWavefield.ts
@@ -1,0 +1,69 @@
+import { Scene } from "./SceneTypes";
+import { compile, deleteBuffer, deleteProgram, deleteVertexArray, link } from "../engine/core/GLUtils";
+
+const VS = `#version 300 es
+layout(location=0) in vec2 a_pos;
+out vec2 vUV;
+void main(){ vUV = a_pos*0.5+0.5; gl_Position = vec4(a_pos,0.0,1.0); }`;
+
+const FS = `#version 300 es
+precision highp float;
+in vec2 vUV;
+uniform float uTime;
+out vec4 frag;
+
+float wave(vec2 p, vec2 dir, float freq, float phase){
+  return sin(6.28318*(dot(p, dir)*freq + phase));
+}
+
+void main(){
+  vec2 p = vUV*2.0 - 1.0;
+  float w1 = wave(p, normalize(vec2(0.9,0.2)), 0.75, uTime*0.07);
+  float w2 = wave(p, normalize(vec2(-0.3,1.0)), 0.95, uTime*0.05+1.7);
+  float w3 = wave(p, normalize(vec2(0.2,-1.0)), 0.60, uTime*0.09+3.4);
+  float s = (w1 + w2 + w3) / 3.0;
+
+  vec3 base = mix(vec3(0.04,0.07,0.09), vec3(0.169,0.894,0.953), 0.5 + 0.5*s);
+  vec3 ember = vec3(1.0,0.431,0.227);
+  vec3 col = mix(base, ember, smoothstep(0.6, 1.0, s*s));
+
+  float d = dot(p,p);
+  float vig = 1.0 - d*0.25;
+  frag = vec4(col*vig, 1.0);
+}
+`;
+
+export class QuantumWavefield implements Scene {
+  name = "QuantumWavefield";
+  private prog!: WebGLProgram;
+  private vao!: WebGLVertexArrayObject;
+  private vbo!: WebGLBuffer;
+  private uTime!: WebGLUniformLocation;
+
+  init(gl: WebGL2RenderingContext) {
+    this.prog = link(gl, compile(gl, gl.VERTEX_SHADER, VS), compile(gl, gl.FRAGMENT_SHADER, FS));
+    this.uTime = gl.getUniformLocation(this.prog, "uTime")!;
+    this.vao = gl.createVertexArray()!;
+    gl.bindVertexArray(this.vao);
+    this.vbo = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+  }
+
+  draw(gl: WebGL2RenderingContext, _camera: { proj: Float32Array; view: Float32Array }, t: number) {
+    gl.useProgram(this.prog);
+    gl.uniform1f(this.uTime, t);
+    gl.bindVertexArray(this.vao);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+    gl.bindVertexArray(null);
+  }
+
+  dispose(gl: WebGL2RenderingContext) {
+    deleteProgram(gl, this.prog);
+    deleteVertexArray(gl, this.vao);
+    deleteBuffer(gl, this.vbo);
+  }
+}

--- a/frontend/src/qce/scenes/SceneManager.ts
+++ b/frontend/src/qce/scenes/SceneManager.ts
@@ -1,0 +1,39 @@
+import type { Scene } from "./SceneTypes";
+
+export class SceneManager {
+  private gl: WebGL2RenderingContext;
+  private scenes: Record<string, Scene> = {};
+  private current?: Scene;
+
+  constructor(gl: WebGL2RenderingContext) {
+    this.gl = gl;
+  }
+
+  register(scene: Scene) {
+    this.scenes[scene.name] = scene;
+  }
+
+  use(name: string) {
+    if (this.current?.name === name) return;
+    const next = this.scenes[name];
+    if (!next) throw new Error(`Scene not found: ${name}`);
+    if (this.current?.dispose) this.current.dispose(this.gl);
+    next.init(this.gl);
+    this.current = next;
+  }
+
+  resize() {
+    this.current?.resize?.(this.gl);
+  }
+
+  draw(camera: { proj: Float32Array; view: Float32Array }, t: number, dt: number) {
+    if (!this.current) return;
+    this.current.draw(this.gl, camera, t, dt);
+  }
+
+  disposeAll() {
+    Object.values(this.scenes).forEach((scene) => {
+      scene.dispose?.(this.gl);
+    });
+  }
+}

--- a/frontend/src/qce/scenes/SceneTypes.ts
+++ b/frontend/src/qce/scenes/SceneTypes.ts
@@ -1,0 +1,12 @@
+export interface Scene {
+  name: string;
+  init(gl: WebGL2RenderingContext): void;
+  resize?(gl: WebGL2RenderingContext): void;
+  draw(
+    gl: WebGL2RenderingContext,
+    camera: { proj: Float32Array; view: Float32Array },
+    t: number,
+    dt: number
+  ): void;
+  dispose?(gl: WebGL2RenderingContext): void;
+}

--- a/frontend/src/qce/scenes/VolumetricSpines.ts
+++ b/frontend/src/qce/scenes/VolumetricSpines.ts
@@ -1,0 +1,103 @@
+import { Scene } from "./SceneTypes";
+import { compile, deleteBuffer, deleteProgram, deleteVertexArray, link } from "../engine/core/GLUtils";
+
+const VS = `#version 300 es
+precision highp float;
+layout(location=0) in vec3 a_pos;
+uniform mat4 uProj, uView;
+out vec3 vPos;
+void main(){
+  vec4 mv = uView * vec4(a_pos,1.0);
+  gl_Position = uProj * mv;
+  vPos = a_pos;
+}
+`;
+
+const FS = `#version 300 es
+precision highp float;
+in vec3 vPos;
+out vec4 frag;
+void main(){
+  vec2 uv = gl_FragCoord.xy / vec2(1920.0, 1080.0);
+  float r = length(fract(uv*60.0)-0.5);
+  float core = exp(-r*20.0);
+  float glow = exp(-r*5.0)*0.6;
+
+  vec3 body = mix(vec3(0.169,0.894,0.953), vec3(1.0,0.431,0.227), smoothstep(-30.0,30.0,vPos.y));
+  vec3 col = body*(0.6+0.4*glow) + vec3(0.02)*glow*2.0;
+
+  float a = clamp(core + glow*0.6, 0.0, 1.0);
+  frag = vec4(col, a);
+}
+`;
+
+export class VolumetricSpines implements Scene {
+  name = "VolumetricSpines";
+  private prog!: WebGLProgram;
+  private uProj!: WebGLUniformLocation;
+  private uView!: WebGLUniformLocation;
+  private vao!: WebGLVertexArrayObject;
+  private buffer!: WebGLBuffer;
+  private count = 0;
+
+  init(gl: WebGL2RenderingContext) {
+    this.prog = link(gl, compile(gl, gl.VERTEX_SHADER, VS), compile(gl, gl.FRAGMENT_SHADER, FS));
+    this.uProj = gl.getUniformLocation(this.prog, "uProj")!;
+    this.uView = gl.getUniformLocation(this.prog, "uView")!;
+
+    const strands = 64;
+    const segs = 128;
+    const data = new Float32Array(strands * segs * 3);
+    let idx = 0;
+    for (let s = 0; s < strands; s++) {
+      let x = (Math.random() - 0.5) * 120;
+      let y = (Math.random() - 0.5) * 60;
+      let z = (Math.random() - 0.5) * 120;
+      let vx = 0;
+      let vy = 0;
+      let vz = 0;
+      for (let i = 0; i < segs; i++) {
+        const t = i / segs;
+        const ax = Math.sin(t * 9.0 + s * 0.3) * 0.8;
+        const ay = Math.cos(t * 7.0 + s) * 0.6;
+        const az = Math.sin(t * 5.0 + s * 0.7) * 0.7;
+        vx = vx * 0.92 + ax;
+        vy = vy * 0.92 + ay;
+        vz = vz * 0.92 + az;
+        x += vx;
+        y += vy;
+        z += vz;
+        data[idx++] = x;
+        data[idx++] = y;
+        data[idx++] = z;
+      }
+    }
+    this.count = strands * segs;
+    this.vao = gl.createVertexArray()!;
+    gl.bindVertexArray(this.vao);
+    this.buffer = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+  }
+
+  draw(gl: WebGL2RenderingContext, camera: { proj: Float32Array; view: Float32Array }) {
+    gl.enable(gl.BLEND);
+    gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    gl.useProgram(this.prog);
+    gl.uniformMatrix4fv(this.uProj, false, camera.proj);
+    gl.uniformMatrix4fv(this.uView, false, camera.view);
+    gl.bindVertexArray(this.vao);
+    gl.drawArrays(gl.LINE_STRIP, 0, this.count);
+    gl.bindVertexArray(null);
+    gl.disable(gl.BLEND);
+  }
+
+  dispose(gl: WebGL2RenderingContext) {
+    deleteProgram(gl, this.prog);
+    deleteVertexArray(gl, this.vao);
+    deleteBuffer(gl, this.buffer);
+  }
+}


### PR DESCRIPTION
## Summary
- add a cinematic mode to the UI with scene toggles and layout switching
- implement a WebGL2-based engine with HDR pipeline, orbital camera, TF particle simulation, and scene manager
- ship four shader-driven cinematic scenes with lifecycle management and integration into the engine

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c9467a34832cbd912de7b5f232d8