### PR TITLE
Implement end-to-end ingestion pipeline and frontend controls

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,96 +3,206 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
+from pgvector.sqlalchemy import Vector as VectorType
 from sqlalchemy import (
     CheckConstraint,
     Column,
     DateTime,
+    Float,
     ForeignKey,
     Index,
     Integer,
     String,
     Text,
     UniqueConstraint,
-    Float,
 )
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import declarative_base, Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, declarative_base, mapped_column, relationship
 
-# import settings for emb_dim
 from settings import settings
-
-# pgvector Vector type (required at runtime & for alembic rendering)
-from pgvector.sqlalchemy import Vector as VectorType
 
 Base = declarative_base()
 
-# --- Tables ---
 
 class Glyph(Base):
-    __tablename__ = "glyphs"
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    kind: Mapped[str] = mapped_column(String, nullable=False)          # e.g., 'message','entity','tag'
-    title: Mapped[str | None] = mapped_column(String, nullable=True)
-    body: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    """Author-curated knowledge artifacts."""
 
-    __table_args__ = (
-        Index("ix_glyphs_kind_created", "kind", "created_at"),
+    __tablename__ = "glyphs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
     )
+
+    __table_args__ = (Index("ix_glyphs_created", "created_at"),)
+
 
 class Message(Base):
+    """Raw textual inputs that flow through the embedding/linking pipeline."""
+
     __tablename__ = "messages"
+
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    source: Mapped[str | None] = mapped_column(String, nullable=True)  # e.g., 'ingest','api'
+    source: Mapped[str | None] = mapped_column(String, nullable=True)
     author: Mapped[str | None] = mapped_column(String, nullable=True)
-    text: Mapped[str] = mapped_column(Text, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    __table_args__ = (Index("ix_messages_created", "created_at"),)
+
+
+class Node(Base):
+    """Unified graph node materialized via triggers from glyphs/messages."""
+
+    __tablename__ = "nodes"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    kind: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
 
     __table_args__ = (
-        Index("ix_messages_created", "created_at"),
+        CheckConstraint("kind IN ('glyph','message')", name="nodes_kind_check"),
+        Index("ix_nodes_kind_created", "kind", "created_at"),
     )
+
+
+class Edge(Base):
+    __tablename__ = "edges"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    src_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    dst_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    rel: Mapped[str | None] = mapped_column(String, nullable=True)
+    weight: Mapped[float | None] = mapped_column(Float, nullable=True, default=1.0)
+    dedupe_key: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    __table_args__ = (
+        Index("ix_edges_src", "src_id"),
+        Index("ix_edges_dst", "dst_id"),
+        Index("ix_edges_created", "created_at"),
+        UniqueConstraint(
+            "src_id",
+            "dst_id",
+            "rel",
+            "dedupe_key",
+            name="edges_src_dst_rel_dedupe_key_key",
+        ),
+    )
+
 
 class Embedding(Base):
     __tablename__ = "embeddings"
+
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    obj_type: Mapped[str] = mapped_column(String, nullable=False)      # 'glyph' | 'message'
+    obj_type: Mapped[str] = mapped_column(String, nullable=False)
     obj_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    model: Mapped[str] = mapped_column(String, nullable=False, default="text-embedding-3-large")
+    model: Mapped[str] = mapped_column(String, nullable=False, default=settings.emb_model)
     dim: Mapped[int] = mapped_column(Integer, nullable=False, default=settings.emb_dim)
-    # pgvector column with tunable dimension
     vec = Column(VectorType(dim=settings.emb_dim), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
 
     __table_args__ = (
         UniqueConstraint("obj_type", "obj_id", "model", name="embeddings_obj_type_obj_id_model_key"),
         CheckConstraint("dim > 0", name="embeddings_dim_check"),
-        CheckConstraint("obj_type in ('glyph','message')", name="embeddings_obj_type_check"),
+        CheckConstraint(
+            "obj_type IN ('glyph','message')",
+            name="embeddings_obj_type_check",
+        ),
         Index("embeddings_obj_type", "obj_type"),
     )
 
-class Edge(Base):
-    __tablename__ = "edges"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    src_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    dst_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
-    kind: Mapped[str] = mapped_column(String, nullable=False)  # e.g., 'semantic','reference','tag'
-    weight: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
-
-    __table_args__ = (
-        Index("ix_edges_src_kind", "src_id", "kind"),
-        Index("ix_edges_dst_kind", "dst_id", "kind"),
-    )
 
 class Tag(Base):
     __tablename__ = "tags"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
-    parent_id: Mapped[int | None] = mapped_column(ForeignKey("tags.id"), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
 
-    parent: Mapped["Tag | None"] = relationship("Tag", remote_side=[id])
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    slug: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    dim: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    vec = Column(VectorType(dim=settings.emb_dim), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    __table_args__ = (Index("ix_tags_slug", "slug"),)
+
+
+class TagLink(Base):
+    __tablename__ = "tag_links"
+
+    parent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True
+    )
+    child_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True
+    )
+    kind: Mapped[str] = mapped_column(String, primary_key=True, default="is_a")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    parent: Mapped["Tag"] = relationship("Tag", foreign_keys=[parent_id])
+    child: Mapped["Tag"] = relationship("Tag", foreign_keys=[child_id])
+
+
+class NodeTag(Base):
+    __tablename__ = "node_tags"
+
+    node_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("nodes.id", ondelete="CASCADE"), primary_key=True
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True
+    )
+    source: Mapped[str] = mapped_column(String, primary_key=True)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+    dedupe_key: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    tag: Mapped["Tag"] = relationship("Tag")
 
     __table_args__ = (
-        Index("ix_tags_name", "name"),
+        CheckConstraint("confidence >= 0 AND confidence <= 1", name="node_tags_confidence_check"),
+        UniqueConstraint("node_id", "tag_id", "source", name="node_tags_node_tag_source_key"),
+        UniqueConstraint("node_id", "tag_id", "dedupe_key", name="node_tags_dedupe_key_key"),
+        Index("ix_node_tags_node", "node_id"),
+        Index("ix_node_tags_tag", "tag_id"),
     )
+
+
+class GraphCoord(Base):
+    __tablename__ = "graph_coords"
+
+    node_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("nodes.id", ondelete="CASCADE"), primary_key=True
+    )
+    layout: Mapped[str] = mapped_column(String, nullable=False, default="auto")
+    x: Mapped[float | None] = mapped_column(Float, nullable=True)
+    y: Mapped[float | None] = mapped_column(Float, nullable=True)
+    z: Mapped[float | None] = mapped_column(Float, nullable=True)
+    t: Mapped[float | None] = mapped_column(Float, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    __table_args__ = (Index("ix_graph_coords_layout", "layout"),)

--- a/backend/app/nlp_extract.py
+++ b/backend/app/nlp_extract.py
@@ -1,57 +1,106 @@
+from __future__ import annotations
 
-import os, numpy as np
+import os
+from typing import Dict, List
+
+import numpy as np
 from sqlalchemy import text as T
 from sqlalchemy.orm import Session
-from storage import SessionLocal
+
 from kafka_bus import consumer, produce
+from services.embeddings import embed_texts
+from storage import SessionLocal
 
-GROUP = os.getenv("KAFKA_GROUP_ID","nlp_extract")
-INGEST_TOPIC = os.getenv("INGEST_TOPIC","nlp.ingest")
-CANDIDATES_TOPIC = os.getenv("CANDIDATES_TOPIC","nlp.candidates")
-EMB_MODEL = os.getenv("EMB_MODEL","text-embedding-3-large@3072")
-EMB_DIM = int(os.getenv("EMB_DIM","384"))
+GROUP = os.getenv("KAFKA_GROUP_ID", "nlp_extract")
+INGEST_TOPIC = os.getenv("INGEST_TOPIC", "nlp.ingest")
+CANDIDATES_TOPIC = os.getenv("CANDIDATES_TOPIC", "nlp.candidates")
+EMB_MODEL = os.getenv("EMB_MODEL", "text-embedding-3-large@3072")
+EMB_BACKEND = os.getenv("EMB_MODEL_BACKEND", "sentence-transformers/all-MiniLM-L6-v2")
+EMB_DIM = int(os.getenv("EMB_DIM", "384"))
 
-_cons = None
+_consumer = None
 
-def _embed_stub(text:str) -> list[float]:
-    seed = abs(hash(text)) % (2**32)
-    rng = np.random.default_rng(seed)
-    v = rng.standard_normal(EMB_DIM).astype(np.float32)
-    v /= (np.linalg.norm(v) + 1e-8)
-    return v.tolist()
-
-def _upsert_embedding(db: Session, obj_type: str, obj_id: str, vec: list[float]):
-    db.execute(T("""
-      INSERT INTO embeddings (obj_type, obj_id, model, dim, vec)
-      VALUES (:t,:id,:m,:d,:v)
-      ON CONFLICT (obj_type, obj_id, model) DO UPDATE
-        SET vec=EXCLUDED.vec, dim=EXCLUDED.dim, created_at=now()
-    """), {"t":obj_type,"id":obj_id,"m":EMB_MODEL,"d":len(vec),"v":vec})
 
 def _ensure_consumer():
-    global _cons
-    if _cons is None:
-        _cons = consumer([INGEST_TOPIC], group_id=GROUP, auto_offset_reset="earliest", max_poll_records=100)
-    return _cons
+    global _consumer
+    if _consumer is None:
+        _consumer = consumer(
+            [INGEST_TOPIC],
+            group_id=GROUP,
+            auto_offset_reset=os.getenv("AUTO_OFFSET_RESET", "earliest"),
+            max_poll_records=int(os.getenv("MAX_POLL_RECORDS", "128")),
+        )
+    return _consumer
+
+
+def _flatten_batch(batch: Dict) -> List:
+    records: List = []
+    for msgs in batch.values():
+        records.extend(msgs)
+    return records
+
+
+def _upsert_embedding(db: Session, obj_type: str, obj_id: str, vec: np.ndarray):
+    payload = vec.astype(np.float32).tolist()
+    db.execute(
+        T(
+            """
+            INSERT INTO embeddings (obj_type, obj_id, model, dim, vec)
+            VALUES (:obj_type, :obj_id, :model, :dim, :vec)
+            ON CONFLICT (obj_type, obj_id, model)
+            DO UPDATE SET vec = EXCLUDED.vec, dim = EXCLUDED.dim, created_at = now()
+            """
+        ),
+        {
+            "obj_type": obj_type,
+            "obj_id": obj_id,
+            "model": EMB_MODEL,
+            "dim": vec.shape[0],
+            "vec": payload,
+        },
+    )
+
 
 def step() -> bool:
     cons = _ensure_consumer()
     if cons is None:
         return False
-    batch = cons.poll(timeout_ms=200, max_records=50) or []
-    if not batch:
+
+    batch = cons.poll(timeout_ms=500, max_records=200) or {}
+    records = _flatten_batch(batch)
+    if not records:
         return False
-    processed = 0
-    for msg in batch:
-        payload = msg.value or {}
+
+    events = []
+    for record in records:
+        payload = getattr(record, "value", None) or {}
         if payload.get("type") != "message.created":
             continue
-        msg_id = payload["id"]
-        content = payload.get("content","")
-        vec = _embed_stub(content)
-        with SessionLocal() as db:
-            _upsert_embedding(db, "message", msg_id, vec)
-            db.commit()
-        produce(CANDIDATES_TOPIC, {"type":"candidates.ready","id":msg_id})
-        processed += 1
-    return processed > 0
+        message_id = payload.get("id")
+        content = (payload.get("content") or "").strip()
+        if not message_id or not content:
+            continue
+        events.append((message_id, content))
+
+    if not events:
+        return False
+
+    vectors = embed_texts([content for _, content in events], EMB_BACKEND)
+    if vectors.shape[1] != EMB_DIM:
+        raise RuntimeError(
+            f"Embedding dimension mismatch: expected {EMB_DIM}, got {vectors.shape[1]} for model {EMB_BACKEND}"
+        )
+
+    with SessionLocal() as db:
+        for (message_id, _), vector in zip(events, vectors):
+            _upsert_embedding(db, "message", message_id, vector)
+        db.commit()
+
+    for message_id, _ in events:
+        produce(
+            CANDIDATES_TOPIC,
+            {"type": "candidates.ready", "id": message_id, "model": EMB_MODEL},
+            key=message_id,
+        )
+
+    return True

--- a/backend/app/routes/api.py
+++ b/backend/app/routes/api.py
@@ -1,21 +1,193 @@
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from __future__ import annotations
+
 from datetime import datetime
+from collections import defaultdict
+from typing import Dict, Iterable, List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
 from db import get_db
-from models import Glyph, Edge
+from kafka_bus import bus_health, produce
+from models import Message, NodeTag, Tag
+from settings import settings
 
 router = APIRouter()
 
+
+class TagAssignment(BaseModel):
+    slug: str
+    name: str
+    confidence: float
+
+
+class MessageCreate(BaseModel):
+    content: str = Field(..., min_length=1, description="Body of the message to ingest")
+    author: str | None = Field(default=None, description="Optional author handle")
+    source: str | None = Field(default="api", description="Provenance identifier")
+    summary: str | None = Field(default=None, description="Optional short summary")
+    tags: List[str] = Field(default_factory=list, description="Optional tag slugs to apply")
+
+
+class MessageResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    content: str
+    author: str | None
+    source: str | None
+    summary: str | None
+    created_at: datetime
+    tags: List[TagAssignment] = Field(default_factory=list)
+
+
 @router.get("/busz")
 def bus_status():
-    return {"enabled": True, "producer_ok": True}
+    """Expose Kafka wiring so operators can validate connectivity."""
 
-@router.post("/produce/message")
-def produce_message(payload: dict, db: Session = Depends(get_db)):
-    text = (payload or {}).get("text", "").strip()
-    g1 = Glyph(kind="glyph", title="Ada", body=text or "pioneer", created_at=datetime.utcnow())
-    g2 = Glyph(kind="glyph", title="Graph", body="data structure", created_at=datetime.utcnow())
-    db.add_all([g1, g2]); db.flush()
-    e = Edge(src_id=g1.id, dst_id=g2.id, kind="studies", weight=0.9, created_at=datetime.utcnow())
-    db.add(e); db.commit()
-    return {"status": "ok"}
+    return bus_health()
+
+
+def _persist_tags(db: Session, message_id: UUID, slugs: List[str]) -> None:
+    if not slugs:
+        return
+
+    normalized = []
+    for slug in slugs:
+        cleaned = slug.strip().lower()
+        if not cleaned:
+            continue
+        normalized.append(cleaned)
+
+    if not normalized:
+        return
+
+    existing = {
+        row.slug: row
+        for row in db.scalars(select(Tag).where(Tag.slug.in_(normalized)))
+    }
+
+    created_ids: dict[str, UUID] = {}
+    for slug in normalized:
+        tag = existing.get(slug)
+        if tag is None:
+            tag = Tag(slug=slug, name=slug.replace("-", " ").title())
+            db.add(tag)
+            db.flush()
+            existing[slug] = tag
+        created_ids[slug] = tag.id
+
+    for slug, tag_id in created_ids.items():
+        db.execute(
+            text(
+                """
+                INSERT INTO node_tags (node_id, tag_id, source, confidence, dedupe_key)
+                VALUES (:node_id, :tag_id, :source, :confidence, :dedupe_key)
+                ON CONFLICT (node_id, tag_id, source)
+                DO UPDATE SET confidence = GREATEST(node_tags.confidence, EXCLUDED.confidence)
+                """
+            ),
+            {
+                "node_id": str(message_id),
+                "tag_id": str(tag_id),
+                "source": "api",
+                "confidence": 0.9,
+                "dedupe_key": f"{message_id}:{tag_id}:api",
+            },
+        )
+
+def _tag_map(db: Session, message_ids: Iterable[UUID]) -> Dict[UUID, List[TagAssignment]]:
+    ids = [mid for mid in message_ids]
+    if not ids:
+        return {}
+
+    rows = db.execute(
+        select(NodeTag.node_id, Tag.slug, Tag.name, NodeTag.confidence)
+            .join(Tag, Tag.id == NodeTag.tag_id)
+            .where(NodeTag.node_id.in_(ids))
+            .order_by(Tag.slug)
+    )
+
+    mapping: Dict[UUID, List[TagAssignment]] = defaultdict(list)
+    for node_id, slug, name, confidence in rows:
+        mapping[node_id].append(
+            TagAssignment(slug=slug, name=name, confidence=float(confidence or 0.0))
+        )
+    return mapping
+
+
+def _message_response(message: Message, tags: List[TagAssignment]) -> MessageResponse:
+    return MessageResponse(
+        id=message.id,
+        content=message.content,
+        author=message.author,
+        source=message.source,
+        summary=message.summary,
+        created_at=message.created_at,
+        tags=tags,
+    )
+
+
+@router.post("/messages", response_model=MessageResponse, status_code=status.HTTP_201_CREATED)
+def create_message(payload: MessageCreate, db: Session = Depends(get_db)):
+    content = payload.content.strip()
+    if not content:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "content cannot be blank")
+
+    summary = payload.summary or content.splitlines()[0][:240]
+
+    message = Message(
+        content=content,
+        author=payload.author,
+        source=payload.source or "api",
+        summary=summary,
+    )
+    db.add(message)
+    db.flush()
+
+    _persist_tags(db, message.id, payload.tags)
+
+    event = {
+        "type": "message.created",
+        "id": str(message.id),
+        "source": message.source,
+        "author": message.author,
+        "content": message.content,
+        "summary": message.summary,
+        "created_at": message.created_at.isoformat(),
+        "tags": payload.tags,
+    }
+
+    dispatched = produce(settings.kafka.ingest_topic, event, key=str(message.id))
+    if not dispatched:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Unable to dispatch ingest event")
+
+    produce(settings.kafka.graph_events_topic, {"type": "message.ingested", "id": str(message.id)})
+
+    tag_lookup = _tag_map(db, [message.id])
+    return _message_response(message, tag_lookup.get(message.id, []))
+
+
+@router.get("/messages/{message_id}", response_model=MessageResponse)
+def read_message(message_id: UUID, db: Session = Depends(get_db)):
+    message = db.get(Message, message_id)
+    if message is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Message not found")
+
+    tag_lookup = _tag_map(db, [message.id])
+    return _message_response(message, tag_lookup.get(message.id, []))
+
+
+@router.get("/messages", response_model=list[MessageResponse])
+def list_messages(
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+):
+    messages = db.scalars(
+        select(Message).order_by(Message.created_at.desc()).limit(limit)
+    ).all()
+    tag_lookup = _tag_map(db, [m.id for m in messages])
+    return [_message_response(message, tag_lookup.get(message.id, [])) for message in messages]

--- a/backend/app/services/embeddings.py
+++ b/backend/app/services/embeddings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import threading
+from functools import lru_cache
+from typing import Iterable, Sequence
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+@lru_cache(maxsize=4)
+def _load_model(model_name: str) -> SentenceTransformer:
+    return SentenceTransformer(model_name, device="cpu")
+
+
+_model_lock = threading.Lock()
+
+
+def embed_texts(
+    texts: Sequence[str] | Iterable[str],
+    model_name: str,
+    normalize: bool = True,
+) -> np.ndarray:
+    """Encode a batch of texts using a cached SentenceTransformer model."""
+
+    # The model loading path is cached but SentenceTransformer is not inherently thread-safe
+    # during the first load, so we protect it with a lock.
+    with _model_lock:
+        model = _load_model(model_name)
+
+    vectors = model.encode(list(texts), convert_to_numpy=True, show_progress_bar=False)
+    if normalize:
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True) + 1e-9
+        vectors = vectors / norms
+    return vectors.astype(np.float32)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ pydantic-settings>=2.2,<3
 Mako>=1.3
 Jinja2>=3.1
 pgvector>=0.2.5
+sentence-transformers==3.0.1


### PR DESCRIPTION
## Summary
- align ORM models with the database schema and expose shared graph/tag metadata classes
- replace the message ingestion API with a Kafka-backed flow that persists tags and lists recent messages
- add a SentenceTransformer-powered embedding service and update the NLP worker to produce real vectors
- refresh the frontend to drive graph parameters, display refresh timestamps, and reuse backend-sourced graph data

## Testing
- python -m compileall backend/app
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d6eb5a5be8832c8dbef9cf7a673724